### PR TITLE
change the location of defination of struct list_head

### DIFF
--- a/master/labs/kernel_api.html
+++ b/master/labs/kernel_api.html
@@ -440,7 +440,7 @@ context.</p>
 way of defining and using lists. This involves using a
 <code class="xref c c-type docutils literal"><span class="pre">struct</span> <span class="pre">list_head</span></code> element in the structure we want to consider as a
 list node. The <code class="xref c c-type docutils literal"><span class="pre">struct</span> <span class="pre">list_head</span></code> is defined in
-<code class="file docutils literal"><span class="pre">include/linux/list.h</span></code> along with all the other functions that manipulate
+<code class="file docutils literal"><span class="pre">include/linux/types.h</span></code> along with all the other functions that manipulate
 the lists. The following code shows the definition of
 the <code class="xref c c-type docutils literal"><span class="pre">struct</span> <span class="pre">list_head</span></code> and the use of an element of this type in another
 well-known structure in the Linux kernel:</p>


### PR DESCRIPTION
struct list_head is defined in <include/linux/types.h> not in <include/linux/list.h>